### PR TITLE
Add reminder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ class WeatherPlugin(AssistantPlugin):
         return "The weather is sunny and 25°C."
 ```
 
+### Built-in Reminder Plugin
+
+This repository also ships with a simple `ReminderPlugin` allowing you to schedule spoken reminders.
+Use a command such as:
+
+```
+remind me to buy milk at 6pm
+```
+
+The assistant will speak the reminder at the requested time while running.
+
 ## Usage
 
 Run the main script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy>=1.24.0
 pandas>=2.0.0
 scikit-learn>=1.3.0
 sentence-transformers>=2.2.2
+dateparser>=1.1.8

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -204,6 +204,11 @@ class PersonalAI:
                 obj = getattr(module, attr)
                 if isinstance(obj, type) and issubclass(obj, AssistantPlugin) and obj is not AssistantPlugin:
                     plugin = obj()
+                    if hasattr(plugin, "setup"):
+                        try:
+                            plugin.setup(self)
+                        except TypeError:
+                            pass
                     self.plugins[plugin.name] = plugin
                     for cmd, handler in plugin.register().items():
                         self.commands[cmd] = handler
@@ -327,6 +332,8 @@ class PersonalAI:
         """
         self.voice.speak("Personal AI online.")
         while True:
+            for rem in self.memory.pop_due_reminders():
+                self.voice.speak(f"Reminder: {rem['text']}")
             heard = self.voice.listen()
             if not heard:
                 continue

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -8,6 +8,10 @@ class AssistantPlugin:
     name: str = "BasePlugin"
     description: str = "Base plugin class."
 
+    def setup(self, assistant: Any) -> None:  # type: ignore[empty-body]
+        """Optional initialization with the assistant instance."""
+        return None
+
     def register(self) -> Dict[str, Callable[[str, Any], Any]]:
         """
         Return a dict mapping command names to handler functions.

--- a/src/plugins/reminder.py
+++ b/src/plugins/reminder.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import re
+import dateparser
+from src.plugins.base import AssistantPlugin
+
+class ReminderPlugin(AssistantPlugin):
+    name = "Reminder"
+    description = "Set and announce time-based reminders."
+
+    def setup(self, assistant) -> None:
+        self.memory = assistant.memory
+
+    def register(self):
+        return {"remind": self.handle_reminder}
+
+    def handle_reminder(self, command: str, *args, **kwargs):
+        match = re.search(r"remind(?: me)? to (.+?) at (.+)", command, re.IGNORECASE)
+        if not match:
+            return "Please specify a reminder like 'remind me to buy milk at 6pm'."
+        task, time_str = match.groups()
+        when = dateparser.parse(time_str)
+        if not when:
+            return f"I couldn't understand the time '{time_str}'."
+        self.memory.add_reminder(task.strip(), when)
+        return f"Okay, I'll remind you to {task.strip()} at {when.strftime('%I:%M %p on %B %d')}"


### PR DESCRIPTION
## Summary
- create `ReminderPlugin` to schedule voice reminders
- extend Memory with add_reminder and pop_due_reminders helpers
- load plugins with optional setup hooks
- announce due reminders in `PersonalAI.run`
- document reminder usage in README
- add `dateparser` to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841165f670483229a0f00feeeb06331