### PR TITLE
Add todo and news plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An advanced, production-grade voice assistant built with Python. Features modula
 - Voice response synthesis (ElevenLabs, pyttsx3 fallback)
 - Conversation memory management
 - **Plugin system**: Easily add new skills/tools
+- Built-in reminders, todo list, and news headlines plugins
 - **Advanced configuration**: Supports `.env` and `config.yaml`
 - Robust error handling and centralized logging
 - Fully type-annotated, documented, and tested
@@ -52,12 +53,14 @@ The assistant loads configuration from `.env` and/or `config.yaml`, with environ
 ```
 OPENAI_API_KEY=your_openai_key
 ELEVENLABS_API_KEY=your_elevenlabs_key
+NEWS_API_KEY=your_news_api_key
 ```
 
 **Example `config.yaml`**
 ```yaml
 openai_api_key: your_openai_key
 elevenlabs_api_key: your_elevenlabs_key
+news_api_key: your_news_api_key
 voice_id: AwbZ3Leiit6t97L6NM4u
 wake_words:
   - hey assistant
@@ -98,6 +101,17 @@ remind me to buy milk at 6pm
 ```
 
 The assistant will speak the reminder at the requested time while running.
+
+### Todo and News Plugins
+
+Additional plugins provide a simple todo list and latest news headlines.
+Use commands such as:
+
+```
+add buy milk to my todo list
+list my todo list
+news
+```
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas>=2.0.0
 scikit-learn>=1.3.0
 sentence-transformers>=2.2.2
 dateparser>=1.1.8
+requests>=2.31.0

--- a/src/config.py
+++ b/src/config.py
@@ -45,6 +45,7 @@ class Settings(BaseModel if USE_PYDANTIC else object):
     ambient_adjust_sec: float = 0.5
     listen_timeout: int = 10
     phrase_time_limit: int = 7
+    news_api_key: str = ""
 
     @property
     def tts_url(self) -> str:
@@ -66,6 +67,7 @@ class Settings(BaseModel if USE_PYDANTIC else object):
             "ambient_adjust_sec": float(_env_or_yaml("AMBIENT_ADJUST_SEC", yaml_cfg, 0.5)),
             "listen_timeout": int(_env_or_yaml("LISTEN_TIMEOUT", yaml_cfg, 10)),
             "phrase_time_limit": int(_env_or_yaml("PHRASE_TIME_LIMIT", yaml_cfg, 7)),
+            "news_api_key": _env_or_yaml("NEWS_API_KEY", yaml_cfg, ""),
         }
         if USE_PYDANTIC:
             try:

--- a/src/memory.py
+++ b/src/memory.py
@@ -39,6 +39,7 @@ class Memory:
             "interactions": [],
             "learned_facts": {},
             "reminders": [],
+            "todo_tasks": [],
             "first_meeting": dt.datetime.now().isoformat(),
         }
 
@@ -104,3 +105,27 @@ class Memory:
             self.data["reminders"] = remaining
             self.save()
         return due
+
+    def add_todo(self, text: str) -> None:
+        """Add a todo task."""
+        self.data.setdefault("todo_tasks", []).append(
+            {
+                "id": dt.datetime.now().isoformat(),
+                "text": text,
+                "done": False,
+            }
+        )
+        self.save()
+
+    def list_todo(self) -> List[str]:
+        """Return a list of incomplete todo task texts."""
+        return [t["text"] for t in self.data.get("todo_tasks", []) if not t.get("done")]
+
+    def complete_todo(self, text: str) -> bool:
+        """Mark a todo task as completed."""
+        for task in self.data.get("todo_tasks", []):
+            if task["text"].lower() == text.lower() and not task.get("done"):
+                task["done"] = True
+                self.save()
+                return True
+        return False

--- a/src/plugins/news.py
+++ b/src/plugins/news.py
@@ -1,0 +1,35 @@
+import requests
+from src.plugins.base import AssistantPlugin
+
+
+class NewsPlugin(AssistantPlugin):
+    """Fetch latest news headlines."""
+
+    name = "News"
+    description = "Get recent news headlines from NewsAPI"
+
+    def setup(self, assistant) -> None:
+        self.api_key = getattr(assistant.cfg, "news_api_key", "")
+        self.session = requests.Session()
+
+    def register(self):
+        return {"news": self.handle_news}
+
+    def handle_news(self, command: str, *args, **kwargs):
+        if not self.api_key:
+            return "News API key is not configured."
+        try:
+            resp = self.session.get(
+                "https://newsapi.org/v2/top-headlines",
+                params={"country": "us", "pageSize": 3, "apiKey": self.api_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            articles = data.get("articles") or []
+            if not articles:
+                return "I couldn't find any news right now."
+            headlines = [a.get("title", "") for a in articles if a.get("title")]
+            return "Here are the latest headlines: " + "; ".join(headlines)
+        except Exception as exc:
+            return f"Failed to fetch news: {exc}"

--- a/src/plugins/todo.py
+++ b/src/plugins/todo.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import re
+from src.plugins.base import AssistantPlugin
+
+
+class TodoPlugin(AssistantPlugin):
+    """Simple todo list management plugin."""
+
+    name = "Todo"
+    description = "Manage a personal todo list."
+
+    def setup(self, assistant) -> None:
+        self.memory = assistant.memory
+
+    def register(self):
+        return {"todo": self.handle_todo}
+
+    def handle_todo(self, command: str, *args, **kwargs):
+        cmd = command.lower()
+        add_match = re.search(r"add (.+?) to(?: my)? todo list", cmd)
+        if add_match:
+            task = add_match.group(1).strip()
+            self.memory.add_todo(task)
+            return f"Added '{task}' to your todo list."
+
+        if any(word in cmd for word in ("list", "show", "what")):
+            tasks = self.memory.list_todo()
+            if not tasks:
+                return "Your todo list is empty."
+            numbered = [f"{i + 1}. {t}" for i, t in enumerate(tasks)]
+            return "Here is your todo list:\n" + "\n".join(numbered)
+
+        done_match = re.search(
+            r"(?:mark|complete|finish|remove) (.+?) (?:from .*|as done)?", cmd
+        )
+        if done_match:
+            task = done_match.group(1).strip()
+            if self.memory.complete_todo(task):
+                return f"Marked '{task}' as done."
+            return f"I couldn't find '{task}' on your todo list."
+
+        return (
+            "To manage your todo list, say something like 'add buy milk to my todo "
+            "list' or 'list my todo list'."
+        )


### PR DESCRIPTION
## Summary
- expand documentation with new built-in plugins
- include `NEWS_API_KEY` in examples
- support `news_api_key` in settings
- extend `Memory` with todo list helpers
- add Todo and News plugins
- require `requests` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431d9b20d483228b86b50211b04766