### PR TITLE
Add Flask-based GUI for assistant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scikit-learn>=1.3.0
 sentence-transformers>=2.2.2
 dateparser>=1.1.8
 requests>=2.31.0
+flask>=2.3.2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
- 
+from .text_voice_io import TextVoiceIO

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -24,7 +24,7 @@ class PersonalAI:
     The main orchestrator for the modular voice assistant.
     Handles command processing, plugin management, and integration with memory, LLM, and voice I/O.
     """
-    def __init__(self, cfg: Settings = Settings()) -> None:
+    def __init__(self, cfg: Settings = Settings(), voice_io: VoiceIO | None = None) -> None:
         """
         Initialize the PersonalAI assistant.
         Args:
@@ -32,7 +32,7 @@ class PersonalAI:
         """
         self.cfg = cfg
         self.memory = Memory(cfg.memory_path, cfg.max_interactions)
-        self.voice = VoiceIO(cfg)
+        self.voice = voice_io if voice_io else VoiceIO(cfg)
         self.llm = LLMClient(cfg, self.memory)
         self.semantic = SemanticMemory(self.memory, cfg)
         self.logger = get_logger(__name__)

--- a/src/text_voice_io.py
+++ b/src/text_voice_io.py
@@ -1,0 +1,12 @@
+class TextVoiceIO:
+    """Simplified voice I/O that captures responses as text."""
+    def __init__(self, settings=None) -> None:
+        self.cfg = settings
+        self.last_output = ""
+
+    def speak(self, text: str) -> None:
+        """Store spoken text for retrieval by the GUI."""
+        self.last_output = text
+
+    def listen(self) -> str:  # pragma: no cover - not used
+        return ""

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Assistant GUI</title>
+    <style>
+        body { background-color: #343541; color: #fff; font-family: Arial, sans-serif; margin: 0; }
+        .container { max-width: 800px; margin: auto; padding: 20px; }
+        .messages { background-color: #202123; padding: 20px; border-radius: 8px; height: 70vh; overflow-y: auto; }
+        .message { padding: 10px; margin: 10px 0; border-radius: 5px; }
+        .user { background-color: #2b2d31; text-align: right; }
+        .assistant { background-color: #444654; text-align: left; }
+        .input-area { display: flex; margin-top: 10px; }
+        input[type=text] { flex: 1; padding: 10px; border: none; border-radius: 5px; }
+        button { margin-left: 10px; padding: 10px 20px; background: #19c37d; color: #fff; border: none; border-radius: 5px; cursor: pointer; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="messages" id="messages"></div>
+    <div class="input-area">
+        <input type="text" id="user-input" placeholder="Type a message" autocomplete="off">
+        <button onclick="send()">Send</button>
+    </div>
+</div>
+<script>
+function addMessage(text, cls){
+    const div = document.createElement('div');
+    div.className = 'message ' + cls;
+    div.textContent = text;
+    document.getElementById('messages').appendChild(div);
+    div.scrollIntoView();
+}
+function send(){
+    const input = document.getElementById('user-input');
+    const msg = input.value.trim();
+    if(!msg) return;
+    addMessage(msg, 'user');
+    input.value='';
+    fetch('/chat', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({message: msg})
+    }).then(r => r.json()).then(data => {
+        addMessage(data.response, 'assistant');
+    });
+}
+</script>
+</body>
+</html>

--- a/web_gui.py
+++ b/web_gui.py
@@ -1,0 +1,25 @@
+from flask import Flask, render_template, request, jsonify
+from src.config import Settings
+from src.assistant import PersonalAI
+from src.text_voice_io import TextVoiceIO
+
+app = Flask(__name__)
+
+cfg = Settings.load()
+voice_io = TextVoiceIO(cfg)
+assistant = PersonalAI(cfg, voice_io=voice_io)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    user_message = data.get('message', '')
+    continue_flag = assistant._process(user_message)
+    response = voice_io.last_output
+    return jsonify({'response': response, 'continue': continue_flag})
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- support injecting custom voice IO into `PersonalAI`
- add simple TextVoiceIO for capturing responses
- implement web-based chat UI with Flask
- style the interface similar to ChatGPT
- include Flask in dependencies

## Testing
- `python -m py_compile web_gui.py src/text_voice_io.py`
- `python -m py_compile src/assistant.py`


------
https://chatgpt.com/codex/tasks/task_e_684327596eb8832285325b30ef46a927