### PR TITLE
Launch web interface by default

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,16 @@
 """
-Entry point for the advanced modular voice assistant.
+Entry point for the voice assistant web interface.
+Running this script starts the Flask GUI and opens it in a browser.
 """
-from src.config import Settings
-from src.assistant import PersonalAI
+import webbrowser
+
+from web_gui import app
+
 
 def main() -> None:
-    cfg = Settings.load()
-    assistant = PersonalAI(cfg)
-    assistant.run()
+    webbrowser.open("http://127.0.0.1:5000")
+    app.run(debug=True)
+
 
 if __name__ == "__main__":
     main()

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,49 +2,71 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Assistant GUI</title>
+    <title>Voice Assistant</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/2.0.0/modern-normalize.min.css" integrity="sha512-F0bnVpkgN1lZ8ljv7weZDJcVEg6L38tnSuwRt+Y9BAnQCK9gI0gbrUWId+jpj52aqEidkmu3Pvb5xKM5M0xX8w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
-        body { background-color: #343541; color: #fff; font-family: Arial, sans-serif; margin: 0; }
-        .container { max-width: 800px; margin: auto; padding: 20px; }
-        .messages { background-color: #202123; padding: 20px; border-radius: 8px; height: 70vh; overflow-y: auto; }
-        .message { padding: 10px; margin: 10px 0; border-radius: 5px; }
-        .user { background-color: #2b2d31; text-align: right; }
-        .assistant { background-color: #444654; text-align: left; }
-        .input-area { display: flex; margin-top: 10px; }
-        input[type=text] { flex: 1; padding: 10px; border: none; border-radius: 5px; }
-        button { margin-left: 10px; padding: 10px 20px; background: #19c37d; color: #fff; border: none; border-radius: 5px; cursor: pointer; }
+        body { background:#f6f8fa;font-family:Arial, sans-serif;margin:0;padding:0; }
+        #root { max-width:800px;margin:40px auto;padding:0 20px; }
+        .chat-box { border:1px solid #ddd;border-radius:8px;overflow:hidden; }
+        .messages { background:#fff;height:60vh;overflow-y:auto;padding:20px; }
+        .message { margin-bottom:10px; }
+        .message.user { text-align:right;color:#333; }
+        .message.ai { text-align:left;color:#444; }
+        .input-area { display:flex;border-top:1px solid #ddd; }
+        .input-area input { flex:1;padding:15px;border:none;font-size:1em; }
+        .input-area button { padding:15px 20px;background:#2f80ed;color:#fff;border:none;font-size:1em;cursor:pointer; }
     </style>
 </head>
 <body>
-<div class="container">
-    <div class="messages" id="messages"></div>
-    <div class="input-area">
-        <input type="text" id="user-input" placeholder="Type a message" autocomplete="off">
-        <button onclick="send()">Send</button>
-    </div>
-</div>
-<script>
-function addMessage(text, cls){
-    const div = document.createElement('div');
-    div.className = 'message ' + cls;
-    div.textContent = text;
-    document.getElementById('messages').appendChild(div);
-    div.scrollIntoView();
-}
-function send(){
-    const input = document.getElementById('user-input');
-    const msg = input.value.trim();
-    if(!msg) return;
-    addMessage(msg, 'user');
+<div id="root"></div>
+<script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+<script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+<script type="text/babel">
+function ChatApp(){
+  const [messages, setMessages] = React.useState([]);
+
+  React.useEffect(() => {
+    fetch('/history').then(r=>r.json()).then(data=>{
+      setMessages(data);
+      setTimeout(()=>{ scrollBottom(); }, 100);
+    });
+  }, []);
+
+  const scrollBottom = () => {
+    const el = document.getElementById('messages');
+    if(el) el.scrollTop = el.scrollHeight;
+  };
+
+  const send = () => {
+    const input = document.getElementById('input');
+    const text = input.value.trim();
+    if(!text) return;
+    setMessages(prev => [...prev, {type:'user', content:text}]);
     input.value='';
     fetch('/chat', {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({message: msg})
-    }).then(r => r.json()).then(data => {
-        addMessage(data.response, 'assistant');
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({message:text})
+    }).then(r=>r.json()).then(data=>{
+      setMessages(prev => [...prev, {type:'ai', content:data.response}]);
+      scrollBottom();
     });
+  };
+
+  return (
+    <div className="chat-box">
+      <div className="messages" id="messages">
+        {messages.map((m,i)=>(<div key={i} className={`message ${m.type}`}>{m.content}</div>))}
+      </div>
+      <div className="input-area">
+        <input id="input" type="text" placeholder="Ask something..." autoComplete="off" onKeyDown={e=>e.key==='Enter'&&send()}/>
+        <button onClick={send}>Send</button>
+      </div>
+    </div>
+  );
 }
+ReactDOM.createRoot(document.getElementById('root')).render(<ChatApp/>);
 </script>
 </body>
 </html>

--- a/web_gui.py
+++ b/web_gui.py
@@ -2,11 +2,24 @@ from flask import Flask, render_template, request, jsonify
 from src.config import Settings
 from src.assistant import PersonalAI
 from src.text_voice_io import TextVoiceIO
+from src.voice import VoiceIO
+
+
+class WebVoiceIO(TextVoiceIO):
+    """Voice I/O that stores output for the GUI and speaks it."""
+
+    def __init__(self, settings) -> None:
+        super().__init__(settings)
+        self._voice = VoiceIO(settings)
+
+    def speak(self, text: str) -> None:
+        super().speak(text)
+        self._voice.speak(text)
 
 app = Flask(__name__)
 
 cfg = Settings.load()
-voice_io = TextVoiceIO(cfg)
+voice_io = WebVoiceIO(cfg)
 assistant = PersonalAI(cfg, voice_io=voice_io)
 
 @app.route('/')
@@ -20,6 +33,18 @@ def chat():
     continue_flag = assistant._process(user_message)
     response = voice_io.last_output
     return jsonify({'response': response, 'continue': continue_flag})
+
+
+@app.route('/history')
+def history():
+    interactions = []
+    for inter in assistant.memory.data.get('interactions', []):
+        if inter['type'] in ('user_command', 'ai_response'):
+            interactions.append({
+                'type': 'user' if inter['type'] == 'user_command' else 'ai',
+                'content': inter['content']
+            })
+    return jsonify(interactions)
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- open the Flask GUI automatically when running `main.py`
- speak responses in the web interface using a new `WebVoiceIO`
- expose chat history for the UI
- rebuild the front-end using a simple React interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a0e04848322830a5c2516b9db07