### PR TITLE
Fix npm launch on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,13 +5,15 @@ Running this script starts the Vite dev server and opens the UI.
 from pathlib import Path
 import subprocess
 import webbrowser
+import os
 
 DEV_URL = "http://localhost:5173"
 
 
 def main() -> None:
     web_dir = Path(__file__).parent / "web"
-    subprocess.Popen(["npm", "run", "dev"], cwd=web_dir)
+    npm_cmd = "npm.cmd" if os.name == "nt" else "npm"
+    subprocess.Popen([npm_cmd, "run", "dev"], cwd=web_dir)
     webbrowser.open(DEV_URL)
 
 


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError when running `python main.py` on Windows by using `npm.cmd`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68433fd8e6448322860cfbd7c20fac3d