### PR TITLE
Improve UI styling and fix chat endpoint

### DIFF
--- a/backend/assistant_api.py
+++ b/backend/assistant_api.py
@@ -11,6 +11,10 @@ class ChatMessage(BaseModel):
     content: str
 
 
+class ChatRequest(BaseModel):
+    messages: List[ChatMessage] = []
+
+
 def create_app(prod: bool = False) -> FastAPI:
     app = FastAPI()
 
@@ -33,8 +37,9 @@ def create_app(prod: bool = False) -> FastAPI:
         return {"status": "ok"}
 
     @app.post("/chat")
-    async def chat(messages: List[ChatMessage]):
-        # Simple echo-style reply using last user message
+    async def chat(payload: ChatRequest):
+        """Echo back the last user message from the list."""
+        messages = payload.messages
         if messages:
             last = messages[-1].content
         else:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="/favicon.ico" />
     <title>Elysia Voice Assistant</title>
   </head>
-  <body class="bg-gray-50 dark:bg-[#343541]">
+  <body class="bg-gradient-to-br from-gray-100 via-white to-gray-50 dark:from-[#343541] dark:via-[#202123] dark:to-[#111]">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ function ChatPanel() {
   }, [dispatch])
 
   return (
-    <div className="flex flex-col flex-1 h-screen">
+    <div className="flex flex-col flex-1 h-screen bg-gradient-to-b from-white via-gray-50 to-gray-100 dark:from-[#2b2d30] dark:via-[#202123] dark:to-[#111]">
       <div className="flex-1 flex flex-col">
         <MessageList messages={state.messages} />
       </div>

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -13,7 +13,12 @@ export default function ChatMessage({ message }: Props) {
     'bg-white dark:bg-[#343541] border border-gray-300/60 dark:border-[#3e3f4b] self-end'
   const assistantStyles = 'bg-[#f7f7f8] dark:bg-[#444654]'
   return (
-    <div className={clsx('my-2 flex', isUser ? 'justify-end' : 'justify-start')}>
+    <div
+      className={clsx(
+        'my-2 flex animate-fade-in',
+        isUser ? 'justify-end' : 'justify-start'
+      )}
+    >
       <div className={clsx(base, isUser ? userStyles : assistantStyles)}>
         {message.content}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,3 +8,19 @@
     @apply bg-gray-100 dark:bg-gray-800 p-4 rounded;
   }
 }
+
+@layer utilities {
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .animate-fade-in {
+    animation: fade-in 0.25s ease-out both;
+  }
+}


### PR DESCRIPTION
## Summary
- fix backend chat endpoint to accept payload with messages list
- add gradient backgrounds for a more polished look
- animate new chat messages with a fade-in effect

## Testing
- `python -m py_compile backend/assistant_api.py`
- `curl -X POST -H 'Content-Type: application/json' -d '{"messages":[{"id":"1","role":"user","content":"hello"}]}' http://127.0.0.1:8000/chat`
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684469a2c38c83228d74ba90697f94c8