### PR TITLE
Enable OpenAI chat responses and speech synthesis

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { StoreProvider, useStore } from './store'
 import MessageList from './components/MessageList'
 import PromptBar from './components/PromptBar'
 import { MoonIcon, SunIcon, PlusIcon } from '@heroicons/react/24/outline'
+import { useSpeechSynthesis } from './hooks/useSpeechSynthesis'
 
 function Sidebar() {
   const [state, dispatch] = useStore()
@@ -30,9 +31,7 @@ function Sidebar() {
           ✕
         </button>
         <button
-          onClick={() => {
-            dispatch({ type: 'addMessage', message: { id: Date.now().toString(), role: 'assistant', content: 'New chat started' } })
-          }}
+          onClick={() => dispatch({ type: 'resetMessages' })}
           className="p-2 flex items-center gap-1"
         >
           <PlusIcon className="h-4 w-4" /> New Chat
@@ -51,6 +50,7 @@ function Sidebar() {
 function ChatPanel() {
   const [state, dispatch] = useStore()
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const { speak } = useSpeechSynthesis()
 
   useEffect(() => {
     const handleShortcut = (e: KeyboardEvent) => {
@@ -66,6 +66,13 @@ function ChatPanel() {
     window.addEventListener('keydown', handleShortcut)
     return () => window.removeEventListener('keydown', handleShortcut)
   }, [dispatch])
+
+  useEffect(() => {
+    const last = state.messages[state.messages.length - 1]
+    if (last && last.role === 'assistant') {
+      speak(last.content)
+    }
+  }, [state.messages, speak])
 
   return (
     <div className="flex flex-col flex-1 h-screen bg-gradient-to-b from-white via-gray-50 to-gray-100 dark:from-[#2b2d30] dark:via-[#202123] dark:to-[#111]">

--- a/frontend/src/components/PromptBar.tsx
+++ b/frontend/src/components/PromptBar.tsx
@@ -12,7 +12,7 @@ inputRef?: React.RefObject<HTMLTextAreaElement>
 }
 
 export default function PromptBar({ onVoiceInput, inputRef }: Props) {
-  const [, dispatch] = useStore()
+  const [state, dispatch] = useStore()
   const [value, setValue] = useState('')
   const [rows, setRows] = useState(1)
   const ref = inputRef ?? useRef<HTMLTextAreaElement>(null)
@@ -23,7 +23,7 @@ export default function PromptBar({ onVoiceInput, inputRef }: Props) {
     dispatch({ type: 'addMessage', message: userMsg })
     setValue('')
     dispatch({ type: 'setStreaming', value: true })
-    const assistantMsg = await sendMessage([...([]), userMsg])
+    const assistantMsg = await sendMessage([...state.messages, userMsg])
     dispatch({ type: 'addMessage', message: assistantMsg })
     dispatch({ type: 'setStreaming', value: false })
   }

--- a/frontend/src/hooks/useSpeechSynthesis.ts
+++ b/frontend/src/hooks/useSpeechSynthesis.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react'
+
+export function useSpeechSynthesis() {
+  const [speaking, setSpeaking] = useState(false)
+
+  const speak = (text: string) => {
+    const synth = window.speechSynthesis
+    if (!synth) return
+    const utter = new SpeechSynthesisUtterance(text)
+    utter.onstart = () => setSpeaking(true)
+    utter.onend = () => setSpeaking(false)
+    synth.speak(utter)
+  }
+
+  return { speak, speaking }
+}

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -12,6 +12,7 @@ type Action =
   | { type: 'addMessage'; message: ChatMessage }
   | { type: 'setStreaming'; value: boolean }
   | { type: 'toggleSidebar' }
+  | { type: 'resetMessages' }
 
 const initialState: State = {
   messages: [],
@@ -27,6 +28,8 @@ function reducer(state: State, action: Action): State {
       return { ...state, streaming: action.value }
     case 'toggleSidebar':
       return { ...state, sidebarOpen: !state.sidebarOpen }
+    case 'resetMessages':
+      return { ...state, messages: [] }
     default:
       return state
   }


### PR DESCRIPTION
## Summary
- call OpenAI from `/chat` endpoint when API key is configured
- add a `useSpeechSynthesis` hook and speak assistant replies
- reset chat history from the sidebar
- send existing messages when sending a new one

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68446bbc14f483229de731ab9cf04a0d